### PR TITLE
Fix Tailwind CSS completions breaking after hyphens

### DIFF
--- a/languages/rstml/config.toml
+++ b/languages/rstml/config.toml
@@ -19,7 +19,7 @@ brackets = [
         "string",
     ] },
 ]
-completion_query_characters = ["-"]
+completion_query_characters = ["-", "."]
 prettier_parser_name = "html"
 
 [jsx_tag_auto_close]

--- a/languages/rstml/injections.scm
+++ b/languages/rstml/injections.scm
@@ -1,4 +1,5 @@
 ((rust_expression) @injection.content
+  (#not-match? @injection.content "^(r#*)?\"")
   (#set! injection.language "rust"))
 
 (block


### PR DESCRIPTION
Fixes Tailwind completions breaking after hyphens in Leptos `class="..."` strings inside RSTML.

Leptos `view!` macro bodies are parsed as injected RSTML inside Rust files. This affects plain class attributes such as:

```rust
view! {
    <button class="px-4 py-2 text-white bg-blue-600">
        "Click"
    </button>
}
```

When `tailwindcss-language-server` is available for the Rust buffer, completions can appear in that string, but the completion query can break once a Tailwind hyphen is typed. For example, completions may appear while typing `text`, but after typing `text-`, the completion query resets. This is the same completion-query behavior described in https://github.com/zed-industries/zed/issues/25670, though that issue was reported for Dioxus and this PR only addresses the Leptos/RSTML case. It also relates to the broader Leptos/Rust Tailwind support request in https://github.com/zed-industries/zed/issues/16371.

The issue is not that RSTML lacks `-` as a completion query character: it already has this in [`languages/rstml/config.toml`](https://github.com/zed-extensions/leptos/blob/main/languages/rstml/config.toml):

```toml
completion_query_characters = ["-"]
```

The issue is where the cursor ends up. RSTML parses the value of attributes like `class="..."` as a string-like Rust expression, and that expression is currently reinjected as Rust in [`languages/rstml/injections.scm`](https://github.com/zed-extensions/leptos/blob/main/languages/rstml/injections.scm). When the cursor is inside the class string, the active scope is therefore the nested Rust layer rather than the RSTML layer. Tailwind can still provide completions when the server is available, but the active Rust completion scope does not use RSTML's hyphen query behavior.

This change keeps string-like RSTML expressions in the RSTML layer by excluding them from the Rust injection:

```scheme
((rust_expression) @injection.content
  (#not-match? @injection.content "^(r#*)?\"")
  (#set! injection.language "rust"))
```

Non-string Rust expressions inside RSTML are still injected as Rust.

This is intentionally limited to the simple Leptos class attribute form:

```rust
class="px-4 text-white bg-blue-600"
```

It does not try to fully support more complex Leptos class syntaxes, such as:

```rust
class=(["text-white", "bg-blue-600"], move || active.get())
class:red=move || active.get()
```

Those cases need more context than this small RSTML injection change provides.

Full support for Leptos-specific syntaxes like tuple classes or `class:*` directives likely needs better Zed support for routing language-server requests across nested Rust/RSTML/Rust language layers. Those cases are harder to express cleanly with only more query special cases in [`languages/rstml/injections.scm`](https://github.com/zed-extensions/leptos/blob/main/languages/rstml/injections.scm).